### PR TITLE
Fix meta description

### DIFF
--- a/layouts/partials/site-head.html
+++ b/layouts/partials/site-head.html
@@ -15,8 +15,8 @@
 
   <title>{{ $pageTitle }}</title>
 
-  <meta property="og:description" content="{{ .Description }}" />
-  <meta name="description" content="{{ .Description }}" />
+  <meta property="og:description" content="{{ $.Site.Params.Description }}" />
+  <meta name="description" content="{{ $.Site.Params.Description }}" />
 
 
   <link rel="stylesheet" href="/lib/swiper-bundle.min.css" />


### PR DESCRIPTION
`config.toml` にある `description` が意図通りに参照できておらず、 `og:description` と `description` が空文字になってしまっていたので修正しました。

https://github.com/nostr-jp/nostr-idol-project-website/blob/8108ad98c67bead60e93fe20ee5df90ba3f98cba/config.toml#L6

ref: https://gohugo.io/variables/site/#the-siteparams-variable