### PR TITLE
Fix meta description for detail pages

### DIFF
--- a/layouts/partials/site-head.html
+++ b/layouts/partials/site-head.html
@@ -15,8 +15,8 @@
 
   <title>{{ $pageTitle }}</title>
 
-  <meta property="og:description" content="{{ $.Site.Params.Description }}" />
-  <meta name="description" content="{{ $.Site.Params.Description }}" />
+  <meta property="og:description" content="{{ if .IsHome }}{{ $.Site.Params.description }}{{ else }}{{ .Description }}{{ end }}" />
+  <meta name="description" content="{{ if .IsHome }}{{ $.Site.Params.description }}{{ else }}{{ .Description }}{{ end }}" />
 
 
   <link rel="stylesheet" href="/lib/swiper-bundle.min.css" />


### PR DESCRIPTION
自分の出した #13 でトップページの `meta description` の空文字は修正されたのですが、代わりに個別ページの方の `meta description` もトップページのものと同じになってしまったので、トップページは `/config.toml` 、個別ページの方は `.Description` が参照されるように修正しました 🙇 

ref: https://gohugo.io/variables/site/#the-siteparams-variable